### PR TITLE
Add Use Ender Bootscreen option to the Creality Ender 3 configuration section

### DIFF
--- a/TH3DUF_R2/Configuration.h
+++ b/TH3DUF_R2/Configuration.h
@@ -320,6 +320,9 @@
 // TMC2208 Creality Board Setting - uncomment this to set the driver type if you are using the TMC Creality board
 //#define TMC_CREALITY_BOARD
 
+// Use Ender Bootscreeen instead of TH3D
+//#define ENDER_BOOT
+
 //=================================================================================================
 // README - THE BELOW SETTINGS ARE ONLY FOR USING THE CR-10S DUAL BOARD WITH THE ENDER 3
 // DO NOT UNCOMMENT THE ABOVE #define ENDER3 LINE IF USING THE DUAL BOARD


### PR DESCRIPTION
I was setting this up on a Creality Ender 3 (Pro) and noticed that its section was missing the option to use the Ender bootscreen configs.

Since all the other Creality Ender printers had it in their sections, I think it was skipped on accident?
